### PR TITLE
✨ feat: Add partial Window support for PaneContorl

### DIFF
--- a/crates/uiautomation/src/controls.rs
+++ b/crates/uiautomation/src/controls.rs
@@ -2,8 +2,6 @@ use std::fmt::Display;
 
 use uiautomation_derive::*;
 use windows::Win32::UI::WindowsAndMessaging::SetForegroundWindow;
-use windows::Win32::UI::WindowsAndMessaging::ShowWindow;
-use windows::Win32::UI::WindowsAndMessaging::SW_SHOWDEFAULT;
 
 use super::actions::*;
 use super::Error;
@@ -1040,21 +1038,11 @@ impl Display for MenuItemControl {
 /// 
 /// + Must support: None
 /// + Conditional support: `Dock`, `Scroll`, `Transform`, `Window`
-#[derive(Debug,	Window, Dock, Scroll, Transform)]
+#[derive(Debug,	Dock, Scroll, Transform, Window)]
 pub struct PaneControl {
     control: UIElement
 }
 
-impl PaneControl {
-    /// Set window visual state to normal.
-    pub fn normal(&self) -> Result<bool> {
-        let hwnd = self.control.get_native_window_handle()?;
-        let ret = unsafe {
-            ShowWindow(hwnd, SW_SHOWDEFAULT)
-        };
-        Ok(ret.as_bool())
-    }
-}
 
 impl Control for PaneControl {
     const TYPE: ControlType = ControlType::Pane;

--- a/crates/uiautomation/src/controls.rs
+++ b/crates/uiautomation/src/controls.rs
@@ -2,6 +2,8 @@ use std::fmt::Display;
 
 use uiautomation_derive::*;
 use windows::Win32::UI::WindowsAndMessaging::SetForegroundWindow;
+use windows::Win32::UI::WindowsAndMessaging::ShowWindow;
+use windows::Win32::UI::WindowsAndMessaging::SW_SHOWDEFAULT;
 
 use super::actions::*;
 use super::Error;
@@ -1037,10 +1039,21 @@ impl Display for MenuItemControl {
 /// Wrapper a Pane element as control. The control type of the element must be `UIA_PaneControlTypeId`.
 /// 
 /// + Must support: None
-/// + Conditional support: `Dock`, `Scroll`, `Transform`
-#[derive(Debug,	Dock, Scroll, Transform)]
+/// + Conditional support: `Dock`, `Scroll`, `Transform`, `Window`
+#[derive(Debug,	Window, Dock, Scroll, Transform)]
 pub struct PaneControl {
     control: UIElement
+}
+
+impl PaneControl {
+    /// Set window visual state to normal.
+    pub fn normal(&self) -> Result<bool> {
+        let hwnd = self.control.get_native_window_handle()?;
+        let ret = unsafe {
+            ShowWindow(hwnd, SW_SHOWDEFAULT)
+        };
+        Ok(ret.as_bool())
+    }
 }
 
 impl Control for PaneControl {

--- a/crates/uiautomation/src/controls.rs
+++ b/crates/uiautomation/src/controls.rs
@@ -1043,7 +1043,6 @@ pub struct PaneControl {
     control: UIElement
 }
 
-
 impl Control for PaneControl {
     const TYPE: ControlType = ControlType::Pane;
 }


### PR DESCRIPTION
使得PaneControl也可以支持将窗格从最小化状态变回正常状态
~~补充:
我不太了解Windows开发，实现上可能有不合理的地方。我发现了下面这个函数才是真正的用来设置VisualState的函数，但是不太会使用，欢迎修改完善！
use windows::Win32::UI::Accessibility::WindowPattern_SetWindowVisualState;~~