### PR TITLE
Add get_(cached)_heading_level and is_(cached)_dialog

### DIFF
--- a/crates/uiautomation/src/core.rs
+++ b/crates/uiautomation/src/core.rs
@@ -17,6 +17,8 @@ use windows::Win32::UI::Accessibility::IUIAutomationCacheRequest;
 use windows::Win32::UI::Accessibility::IUIAutomationCondition;
 use windows::Win32::UI::Accessibility::IUIAutomationElement;
 use windows::Win32::UI::Accessibility::IUIAutomationElement3;
+use windows::Win32::UI::Accessibility::IUIAutomationElement8;
+use windows::Win32::UI::Accessibility::IUIAutomationElement9;
 use windows::Win32::UI::Accessibility::IUIAutomationElementArray;
 use windows::Win32::UI::Accessibility::IUIAutomationNotCondition;
 use windows::Win32::UI::Accessibility::IUIAutomationOrCondition;
@@ -36,6 +38,7 @@ use crate::filters::FnFilter;
 use crate::inputs::Mouse;
 use crate::patterns::UIPatternType;
 use crate::types::ElementMode;
+use crate::types::HeadingLevel;
 use crate::types::OrientationType;
 use crate::types::PropertyConditionFlags;
 use crate::types::TreeScope;
@@ -1096,6 +1099,38 @@ impl UIElement {
         }
 
         Ok(())
+    }
+
+    pub fn get_heading_level(&self) -> Result<HeadingLevel> {
+        let element8: IUIAutomationElement8 = self.element.cast()?;
+        let heading_level = unsafe {
+            element8.CurrentHeadingLevel()?
+        };
+        Ok(heading_level.into())
+    }
+
+    pub fn get_cached_heading_level(&self) -> Result<HeadingLevel> {
+        let element8: IUIAutomationElement8 = self.element.cast()?;
+        let heading_level = unsafe {
+            element8.CachedHeadingLevel()?
+        };
+        Ok(heading_level.into())
+    }
+
+    pub fn is_dialog(&self) -> Result<bool> {
+        let element9: IUIAutomationElement9 = self.element.cast()?;
+        let got = unsafe {
+            element9.CurrentIsDialog()?
+        };
+        Ok(got.as_bool())
+    }
+
+    pub fn is_cached_dialog(&self) -> Result<bool> {
+        let element9: IUIAutomationElement9 = self.element.cast()?;
+        let got = unsafe {
+            element9.CachedIsDialog()?
+        };
+        Ok(got.as_bool())
     }
 
     pub(crate) fn to_elements(elements: IUIAutomationElementArray) -> Result<Vec<UIElement>> {
@@ -2302,6 +2337,8 @@ mod tests {
         println!("ProviderDescription: {}", element.get_provider_description().unwrap());
         println!("IsPassword: {}", element.is_password().unwrap());
         println!("AutomationId: {}", element.get_automation_id().unwrap());
+        println!("HeadingLevel: {}", element.get_heading_level().unwrap());
+        println!("IsDialog: {}", element.is_dialog().unwrap());
     }
 
     #[test]

--- a/crates/uiautomation/src/types.rs
+++ b/crates/uiautomation/src/types.rs
@@ -958,6 +958,25 @@ pub enum AnnotationType {
     Mathematics = 60023i32,
 }
 
+/// Defines enum for `windows::Win32::UI::Accessibility::UIA_HEADINGLEVEL_ID`.
+///
+/// This set of constants describes the named constants used to identify the heading level of a UI Automation element.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumConvert)]
+#[map_as(windows::Win32::UI::Accessibility::UIA_HEADINGLEVEL_ID)]
+pub enum HeadingLevel {
+    HeadingLevelNone = 80050i32,
+    HeadingLevel1 = 80051i32,
+    HeadingLevel2 = 80052i32,
+    HeadingLevel3 = 80053i32,
+    HeadingLevel4 = 80054i32,
+    HeadingLevel5 = 80055i32,
+    HeadingLevel6 = 80056i32,
+    HeadingLevel7 = 80057i32,
+    HeadingLevel8 = 80058i32,
+    HeadingLevel9 = 80059i32
+}
+
 /// Defines enum for `windows::Win32::UI::Accessibility::UIA_STYLE_ID`.
 /// 
 /// This set of constants describes the named constants used to identify the visual style of text in a document.


### PR DESCRIPTION
Add get_(cached)_heading_level and is_(cached)_dialog using IUIAutomationElement8/9.

Background:
IUIAutomationElement8/9 offer a simpler and streamlined way to access the *UIProperty::HeadingLevel* and *UIProperty::IsDialog* properties.