### PR TITLE
Fix panic! on HeadingLevel.into()

### DIFF
--- a/crates/uiautomation/src/core.rs
+++ b/crates/uiautomation/src/core.rs
@@ -1106,7 +1106,7 @@ impl UIElement {
         let heading_level = unsafe {
             element8.CurrentHeadingLevel()?
         };
-        Ok(heading_level.into())
+        heading_level.try_into()
     }
 
     pub fn get_cached_heading_level(&self) -> Result<HeadingLevel> {
@@ -1114,7 +1114,7 @@ impl UIElement {
         let heading_level = unsafe {
             element8.CachedHeadingLevel()?
         };
-        Ok(heading_level.into())
+        heading_level.try_into()
     }
 
     pub fn is_dialog(&self) -> Result<bool> {

--- a/crates/uiautomation/src/types.rs
+++ b/crates/uiautomation/src/types.rs
@@ -970,7 +970,7 @@ pub enum AnnotationType {
 /// This set of constants describes the named constants used to identify the heading level of a UI Automation element.
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumConvert)]
-#[map_as(windows::Win32::UI::Accessibility::UIA_HEADINGLEVEL_ID)]
+#[try_map_as(windows::Win32::UI::Accessibility::UIA_HEADINGLEVEL_ID)]
 pub enum HeadingLevel {
     HeadingLevelNone = 80050i32,
     HeadingLevel1 = 80051i32,

--- a/crates/uiautomation_derive/src/enum_derives.rs
+++ b/crates/uiautomation_derive/src/enum_derives.rs
@@ -103,3 +103,20 @@ pub(crate) fn impl_map_as(type_path: Path, enum_item: ItemEnum) -> TokenStream {
 
     gen.into()
 }
+
+pub(crate) fn impl_try_map_as(type_path: Path, enum_item: ItemEnum) -> TokenStream {
+    let enum_name = &enum_item.ident;
+
+    let gen = quote! {
+        #enum_item
+
+        impl TryFrom<#type_path> for #enum_name {
+            type Error = super::errors::Error;
+            fn try_from(value: #type_path) -> super::errors::Result<Self> {
+                value.0.try_into()
+            }
+        }
+    };
+
+    gen.into()
+}

--- a/crates/uiautomation_derive/src/lib.rs
+++ b/crates/uiautomation_derive/src/lib.rs
@@ -164,3 +164,11 @@ pub fn map_as(args: TokenStream, item: TokenStream) -> TokenStream {
 
     impl_map_as(type_path, enum_item)
 }
+
+#[proc_macro_attribute]
+pub fn try_map_as(args: TokenStream, item: TokenStream) -> TokenStream {
+    let enum_item: ItemEnum = syn::parse(item).expect("#[try_map_as()] must be used on enums only");
+    let type_path: Path = syn::parse(args).expect("#[try_map_as() requires type path");
+
+    impl_try_map_as(type_path, enum_item)
+}


### PR DESCRIPTION
Fix panic! on HeadingLevel.into() when elements (such as Chrome DevTools tree items) return values larger than 80059i32 (HeadingLevel9)

Screenshot of a Chrome DevTools tree item in Accessibility Insights:
![image (4)](https://github.com/user-attachments/assets/6ef40b07-e411-4742-b4ba-7d27a4daf30d)
