### PR TITLE
feat: Allow using the input parser outside of uiautomation-rs

### DIFF
--- a/crates/uiautomation/src/inputs.rs
+++ b/crates/uiautomation/src/inputs.rs
@@ -92,7 +92,7 @@ impl InputItem {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-struct Input {
+pub struct Input {
     holdkeys: Vec<VIRTUAL_KEY>,
     items: Vec<InputItem>,
 }
@@ -133,7 +133,7 @@ impl Input {
         }
     }
 
-    fn create_inputs(&self) -> Result<Vec<INPUT>> {
+    pub fn create_inputs(&self) -> Result<Vec<INPUT>> {
         let mut inputs: Vec<INPUT> = Vec::new();
 
         for holdkey in &self.holdkeys {
@@ -385,16 +385,16 @@ impl Input {
     }
 }
 
-struct Parser {
+pub struct Parser {
     ignore_err: bool,
 }
 
 impl Parser {
-    fn new(ignore_err: bool) -> Self {
+    pub fn new(ignore_err: bool) -> Self {
         Self { ignore_err }
     }
 
-    fn parse_input(&self, expression: &str) -> Result<Vec<Input>> {
+    pub fn parse_input(&self, expression: &str) -> Result<Vec<Input>> {
         let mut inputs: Vec<Input> = Vec::new();
 
         let mut expr = expression.chars();


### PR DESCRIPTION
With this change it would be possible to use a proprietary Keyboard implementation.

In our case we would like to replace the Keyboard::wait() sleep by an async sleep from tokio:

```rust
async fn send_keys(keys: &str, interval: Option<std::time::Duration>) -> uiautomation::Result<()> {
    let inputs = uiautomation::inputs::Parser::new(true).parse_input(keys)?;
    for ref input in inputs {
        let input_keys = input.create_inputs()?;
        send_keyboard(&input_keys, interval).await?;
    }

    Ok(())
}

async fn send_keyboard(
    input_keys: &[INPUT],
    interval: Option<std::time::Duration>,
) -> uiautomation::Result<()> {
    if let Some(interval) = interval {
        for input_key in input_keys {
            let input_key_slice: [INPUT; 1] = [input_key.clone()];
            send_input(&input_key_slice)?;

            tokio::time::sleep(interval).await;
        }
    } else {
        send_input(input_keys)?;
    }
    Ok(())
}
```